### PR TITLE
Fix for "upstream too big" errors in proxy.

### DIFF
--- a/nginx/proxy_nossl.conf
+++ b/nginx/proxy_nossl.conf
@@ -13,6 +13,8 @@ server {
     proxy_set_header        X-Forwarded-Proto $scheme;
     proxy_pass http://target_service;
     proxy_read_timeout  90;
+    proxy_buffers 8 16k;
+    proxy_buffer_size 32k;
     #auth_basic              "Restricted";
     #auth_basic_user_file    /etc/secrets/htpasswd; 
   }

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -43,6 +43,8 @@ server {
       proxy_pass              http://target_service;
       proxy_read_timeout      90;
       proxy_redirect          http:// https://;
+      proxy_buffers 8 16k;
+      proxy_buffer_size 32k;
       #auth_basic              "Restricted";
       #auth_basic_user_file    /etc/secrets/htpasswd; 
   }


### PR DESCRIPTION
We were seeing a bunch of these:

upstream sent too big header while reading response header from upstream

On sidekiq pages in integrations apps. SO suggests the changes I've made
here, though those numbers are entirely arbitrary. I think I've just
doubled the default numbers. It seems to work. The memory consumption
numbers aren't crazy after the change.

I have been running this in production on integrations-related apps and it is fine. I'm cutting a release with these changes.
